### PR TITLE
test: condition tests

### DIFF
--- a/test_data/cond.bad.nix
+++ b/test_data/cond.bad.nix
@@ -1,0 +1,13 @@
+{
+  singleline = xxx: if true then true else false
+    ;
+
+  multiline = xxx:
+    if
+    true
+    then
+    true
+    else
+    false
+    ;
+}

--- a/test_data/cond.good.nix
+++ b/test_data/cond.good.nix
@@ -1,0 +1,12 @@
+{
+  singleline = xxx:
+    if true then true else false
+    ;
+
+  multiline = xxx:
+    if true then
+      true
+    else
+      false
+    ;
+}


### PR DESCRIPTION
multi-line conditions should get indented

It's certainly not covering all of the cases. I haven't really thought about what happens if the condition test is really long for example