### PR TITLE
force line break before first function argument

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -60,7 +60,7 @@ pub(crate) fn spacing() -> SpacingDsl {
         .inside(NODE_SET).between(NODE_SET_ENTRY, TOKEN_COMMENT).single_space_or_optional_newline()
 
         // {arg}: 92 => { arg }: 92
-        .inside(NODE_PATTERN).after(T!["{"]).single_space()
+        .inside(NODE_PATTERN).after(T!["{"]).single_space_or_newline()
         .inside(NODE_PATTERN).before(T!["}"]).single_space_or_newline()
         // { }: 92 => {}: 92
         .inside(NODE_PATTERN).between(T!["{"], T!["}"]).no_space()
@@ -129,6 +129,7 @@ pub(crate) fn indentation() -> IndentDsl {
         .inside(NODE_LIST).indent(VALUES)
         .inside(ENTRY_OWNERS).indent([NODE_SET_ENTRY, NODE_INHERIT])
 
+        .inside(NODE_PATTERN).indent(NODE_PAT_ENTRY)
         .inside(NODE_LAMBDA).when(lambda_body_not_on_top_level).indent(VALUES)
         .inside(NODE_APPLY).when(apply_arg).indent(VALUES)
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -144,6 +144,7 @@ pub(crate) fn indentation() -> IndentDsl {
         // FIXME: don't force indent if comment is on the first line
         .inside(NODE_LIST).indent(TOKEN_COMMENT)
         .inside(ENTRY_OWNERS).indent(TOKEN_COMMENT)
+        .inside(NODE_PATTERN).indent(TOKEN_COMMENT)
         ;
     dsl
 }

--- a/test_data/fn_args_multiline.good.nix
+++ b/test_data/fn_args_multiline.good.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{
+  stdenv
 , lib
 , curl
 }:

--- a/test_data/indented_lambda.bad.nix
+++ b/test_data/indented_lambda.bad.nix
@@ -1,0 +1,6 @@
+{  toINI = {
+  mkSectionName ? (name: libStr.escape [ "[" "]" ] name)
+  , mkKeyValue ? mkKeyValueDefault {} "="
+  }: attrsOfAttrs:
+    mapAttrsToStringsSep "\n" mkSection attrsOfAttrs;
+}

--- a/test_data/indented_lambda.bad.nix
+++ b/test_data/indented_lambda.bad.nix
@@ -1,4 +1,5 @@
 {  toINI = {
+  # parameter comment
   mkSectionName ? (name: libStr.escape [ "[" "]" ] name)
   , mkKeyValue ? mkKeyValueDefault {} "="
   }: attrsOfAttrs:

--- a/test_data/indented_lambda.good.nix
+++ b/test_data/indented_lambda.good.nix
@@ -1,5 +1,6 @@
 {
   toINI = {
+    # parameter comment
     mkSectionName ? (name: libStr.escape [ "[" "]" ] name)
   , mkKeyValue ? mkKeyValueDefault {} "="
   }: attrsOfAttrs:

--- a/test_data/indented_lambda.good.nix
+++ b/test_data/indented_lambda.good.nix
@@ -1,0 +1,7 @@
+{
+  toINI = {
+    mkSectionName ? (name: libStr.escape [ "[" "]" ] name)
+  , mkKeyValue ? mkKeyValueDefault {} "="
+  }: attrsOfAttrs:
+    mapAttrsToStringsSep "\n" mkSection attrsOfAttrs;
+}

--- a/test_data/nested_indent.good.nix
+++ b/test_data/nested_indent.good.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import ./nix/nixpkgs.nix {}
+{
+  pkgs ? import ./nix/nixpkgs.nix {}
 , src ? builtins.fetchGit {
     url = ./.;
     ref = "HEAD";


### PR DESCRIPTION
It's neat that `{` and `,` align in specific cases, but unfortunately
that forces us to indent arguments too much in cases like this:

```
  fooo = { x
         , y
	 } :
```

closes #46