### PR TITLE
implement new version of indentation DLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rnix 0.6.0 (git+https://gitlab.com/jD91mZM2/rnix.git)",
+ "unindent 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -427,6 +428,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unindent"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unindent 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "834b4441326c660336850c5c0926cc20548e848967a5f57bc20c2b741c8d41f4"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ members = [ "./wasm" ]
 [dependencies]
 clap = "2.33.0"
 rnix = { git = "https://gitlab.com/jD91mZM2/rnix.git" }
+
+[dev-dependencies]
+unindent = "0.1.3"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8,7 +8,7 @@ mod fixes;
 use rnix::{SmolStr, SyntaxNode, TextRange};
 
 use crate::{
-    dsl::{IndentDsl, SpacingDsl},
+    dsl::{SpacingDsl, IndentDsl},
     engine::fmt_model::{BlockPosition, FmtModel, SpaceBlock, SpaceBlockOrToken},
     pattern::PatternSet,
     tree_utils::walk_non_whitespace,
@@ -34,7 +34,6 @@ pub(crate) fn format(
     }
 
     // Next, for each node which starts the newline, adjust the indent.
-    let indent_rule_set = PatternSet::new(indent_dsl.rules.iter());
     let anchor_set = PatternSet::new(indent_dsl.anchors.iter());
     for element in walk_non_whitespace(root) {
         let block = model.block_for(element, BlockPosition::Before);
@@ -55,7 +54,7 @@ pub(crate) fn format(
             continue;
         }
 
-        let mut matching = indent_rule_set.matching(element);
+        let mut matching = indent_dsl.rules.iter().filter(|it| it.matches(element));
         if let Some(rule) = matching.next() {
             rule.apply(element, &mut model, &anchor_set);
             assert!(matching.next().is_none(), "more that one indent rule matched");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl FmtDiff {
 
 pub fn reformat_node(node: &SyntaxNode) -> FmtDiff {
     let spacing = rules::spacing();
-    let indentation = rules::indentation();
+    let indentation = rules::indentation2();
     engine::format(&spacing, &indentation, node)
 }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -11,7 +11,7 @@ use rnix::{SyntaxElement, SyntaxKind};
 ///
 /// It is like `Box<dyn Fn(SyntaxElement)> -> bool`, but with additional
 /// convenience methods (for example, you can `&` two patterns). `Pattern` also
-/// knows the set of node types which *could* mach, which allows to implement
+/// knows the set of node types which *could* match, which allows to implement
 /// matching over a set of patterns efficiently.
 ///
 /// Currently, we liberally box predicates inside of `Pattern`s, as there's only

--- a/test_data/curried_fn.good.nix
+++ b/test_data/curried_fn.good.nix
@@ -4,5 +4,5 @@
       err = t: v: abort
         "oups";
     in
-    92;
+      92;
 }

--- a/test_data/indent_let.good.nix
+++ b/test_data/indent_let.good.nix
@@ -3,4 +3,4 @@ let
   y = 2;
   inherit z;
 in
-x + y + z
+  x + y + z

--- a/test_data/top_level_with.good.nix
+++ b/test_data/top_level_with.good.nix
@@ -3,4 +3,4 @@ with stdenv.lib;
 let
   foo = 92;
 in
-foo
+  foo


### PR DESCRIPTION
I've looked how Kotlin handles this and I liked the approach:

https://github.com/JetBrains/kotlin/blob/7d173ed3856e429739b55d8c3892e1b85ca41571/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt#L682-L690

The main trick they use is negative rules: "indent all children except
X". They nicely handle comments and in general simplify things a bit.

I've also added names to rules to as a step towards future debug mode,
as well as an ability to specify simple tests in-line, which should
help with long-term rule maintainability.

closes #71, #65 

prerequisite of #74