### PR TITLE
Add ability to print syntax tree in JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +185,8 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rnix 0.6.0 (git+https://github.com/nix-community/rnix-parser.git)",
+ "rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "unindent 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -249,6 +256,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_unit 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -262,11 +270,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "same-file"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -293,6 +321,9 @@ dependencies = [
 name = "text_unit"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "textwrap"
@@ -446,6 +477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ec16832258409d571aaef8273f3c3cc5b060d784e159d1a0f3b0017308f84a7"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -459,7 +491,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rnix 0.6.0 (git+https://github.com/nix-community/rnix-parser.git)" = "<none>"
 "checksum rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dc2b79612dedc9004083a61448eb669d336d56690aab29fbd7249e8c8ab41d8c"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
+"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
+"checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
+"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum smol_str 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "590700be3630457c56f8c73c0ea39881476ad7076cd84057d44f4f38f79914fb"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c65d951ab12d976b61a41cf9ed4531fc19735c6e6d84a4bb1453711e762ec731"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,14 @@ clap = "2.33.0"
 ignore = "0.4.10"
 rnix = { git = "https://github.com/nix-community/rnix-parser.git" }
 
+# Enable serialization support for rnix syntax trees.
+# Ideally, the feature should be enabled only for binary,
+# but Cargo can't express that nicely yet.
+serde_json = "1.0"
+
+[dependencies.rowan]
+version = "0.6.2"
+features = [ "serde1" ]
+
 [dev-dependencies]
 unindent = "0.1.3"


### PR DESCRIPTION
This might be useful to add custom post-processing to formatting.

See https://discourse.nixos.org/t/text-based-ir-for-nix-formatters/3543

<details>
<summary>Example Output</summary>

```
18:03:01|~/projects/nixpkgs-fmt|serde✓
λ cargo run -- --parse --json --pretty < ~/tmp/ex.nix
   Compiling nixpkgs-fmt v0.1.0 (/home/matklad/projects/nixpkgs-fmt)
    Finished dev [unoptimized + debuginfo] target(s) in 0.92s
     Running `target/debug/nixpkgs-fmt --parse --json --pretty`
{
  "kind": "NODE_ROOT",
  "text_range": [
    0,
    8
  ],
  "children": [
    {
      "kind": "NODE_OPERATION",
      "text_range": [
        0,
        8
      ],
      "children": [
        {
          "kind": "NODE_LIST",
          "text_range": [
            0,
            2
          ],
          "children": [
            {
              "kind": "TOKEN_SQUARE_B_OPEN",
              "text_range": [
                0,
                1
              ],
              "text": "["
            },
            {
              "kind": "TOKEN_SQUARE_B_CLOSE",
              "text_range": [
                1,
                2
              ],
              "text": "]"
            }
          ]
        },
        {
          "kind": "TOKEN_WHITESPACE",
          "text_range": [
            2,
            3
          ],
          "text": " "
        },
        {
          "kind": "TOKEN_CONCAT",
          "text_range": [
            3,
            5
          ],
          "text": "++"
        },
        {
          "kind": "TOKEN_WHITESPACE",
          "text_range": [
            5,
            6
          ],
          "text": " "
        },
        {
          "kind": "NODE_LIST",
          "text_range": [
            6,
            8
          ],
          "children": [
            {
              "kind": "TOKEN_SQUARE_B_OPEN",
              "text_range": [
                6,
                7
              ],
              "text": "["
            },
            {
              "kind": "TOKEN_SQUARE_B_CLOSE",
              "text_range": [
                7,
                8
              ],
              "text": "]"
            }
          ]
        }
      ]
    }
  ]
}

18:03:06|~/projects/nixpkgs-fmt|serde✓
λ cat ~/tmp/ex.nix 
[] ++ []⏎
```

</details>