### PR TITLE
pre-commit: use the current nixpkgs-fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,17 @@ repos:
     -   id: fmt
     -   id: cargo-check
 
--   repo: https://github.com/nix-community/nixpkgs-fmt
-    rev: pre-commit-hook
+-   repo: local
     hooks:
-    -   id: nixpkgs-fmt
-        exclude: >
-            (?x)^(
-                nix/sources.nix|
-                test_data/.*
-            )$
+    -  id: nixpkgs-fmt
+       name: nixpkgs-fmt
+       description: Format nix code with nixpkgs-fmt.
+       entry: nixpkgs-fmt --in-place
+       language: rust
+       files: \.nix$
+       minimum_pre_commit_version: 1.18.1
+       exclude: >
+           (?x)^(
+               nix/sources.nix|
+               test_data/.*
+           )$

--- a/ci.sh
+++ b/ci.sh
@@ -16,10 +16,15 @@ run() {
 
 mkdir -p "${TMPDIR}"
 
-run pre-commit run --all-files
-
+# build nixpkgs-fmt
 run cargo build --verbose
 
+# run after build, pre-commit needs nixpkgs-fmt
+run pre-commit run --all-files
+
+# run the tests
+run cargo test --verbose
+
+# generate the webassembly page
 run ./wasm/build.sh
 
-run cargo test --verbose


### PR DESCRIPTION
Format the nix code with the current version of nixpkgs-fmt instead of
master.