### PR TITLE
main: remove the --in-place flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -  id: nixpkgs-fmt
        name: nixpkgs-fmt
        description: Format nix code with nixpkgs-fmt.
-       entry: nixpkgs-fmt --in-place
+       entry: nixpkgs-fmt
        language: rust
        files: \.nix$
        minimum_pre_commit_version: 1.14.2

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -  id: nixpkgs-fmt
    name: nixpkgs-fmt
    description: Format nix code with nixpkgs-fmt.
-   entry: nixpkgs-fmt --in-place
+   entry: nixpkgs-fmt
    language: rust
    files: \.nix$
    minimum_pre_commit_version: 1.18.1

--- a/README.md
+++ b/README.md
@@ -85,13 +85,12 @@ USAGE:
     nixpkgs-fmt [FLAGS] [FILE]...
 
 FLAGS:
-    -h, --help        Prints help information
-    -i, --in-place    Overwrite FILE in place
-        --parse       Show syntax tree instead of reformatting
-    -V, --version     Prints version information
+    -h, --help       Prints help information
+        --parse      Show syntax tree instead of reformatting
+    -V, --version    Prints version information
 
 ARGS:
-    <FILE>...    File to reformat
+    <FILE>...    File to reformat in place. If no file is passed, read from stdin.
 
 ```
 ## Installation


### PR DESCRIPTION
The --output flag was removed to handle formatting multiple files at the
same time. But since that flag is missing, it doesn't make sense to
output multiple files on stdout as well.

If the user wants to format a file and write the output to a different
place, use stdin and stdout.