### PR TITLE
Expose diff function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ version = "0.3.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rnix 0.6.0 (git+https://github.com/nix-community/rnix-parser.git)",
+ "rnix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "unindent 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,7 +244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rnix"
 version = "0.6.0"
-source = "git+https://github.com/nix-community/rnix-parser.git#77b8e4b39f866c531e1bc4095ddc83a96d9c1e99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -488,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
-"checksum rnix 0.6.0 (git+https://github.com/nix-community/rnix-parser.git)" = "<none>"
+"checksum rnix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5f49df420adaf4b62b490d9a31dbcac014764a5dace40af2b720e7c18b5f9bb"
 "checksum rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dc2b79612dedc9004083a61448eb669d336d56690aab29fbd7249e8c8ab41d8c"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [ "./wasm" ]
 [dependencies]
 clap = "2.33.0"
 ignore = "0.4.10"
-rnix = { git = "https://github.com/nix-community/rnix-parser.git" }
+rnix = "0.6.0"
 
 # Enable serialization support for rnix syntax trees.
 # Ideally, the feature should be enabled only for binary,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,23 @@ pub struct FmtDiff {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct AtomEdit {
-    delete: TextRange,
-    insert: SmolStr,
+pub struct AtomEdit {
+    pub delete: TextRange,
+    pub insert: SmolStr,
 }
 
 impl FmtDiff {
+    /// Get the diff of deletes and inserts
+    pub fn text_diff(&self) -> &[AtomEdit] {
+        &self.edits
+    }
+
+    /// Whether or not formatting did caused any changes
     pub fn has_changes(&self) -> bool {
         !self.edits.is_empty()
     }
 
+    /// Apply the formatting suggestions and return the new string
     pub fn to_string(&self) -> String {
         // TODO: don't copy strings all over the place
         let old_text =
@@ -62,6 +69,7 @@ impl FmtDiff {
         buf
     }
 
+    /// Apply the formatting suggestions and return the new node
     pub fn to_node(&self) -> SyntaxNode {
         unimplemented!()
     }


### PR DESCRIPTION
For using this in a library, it would be great to have the original
diff available. Example usecase is embedding this inside rnix-lsp
without sending the entire file back, but rather just the areas that
were changed.