### PR TITLE
Explain mode

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -1,4 +1,6 @@
 //! This module contains a definition of pattern-based formatting DSL.
+use std::fmt;
+
 use rnix::SyntaxElement;
 
 use crate::{
@@ -217,6 +219,12 @@ pub(crate) enum IndentValue {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RuleName(&'static str);
+
+impl fmt::Display for RuleName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
 
 impl RuleName {
     pub(crate) fn new(name: &'static str) -> RuleName {

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -13,6 +13,7 @@ use crate::{
 /// `IndentRule` for that!
 #[derive(Debug)]
 pub(crate) struct SpacingRule {
+    pub(crate) name: Option<RuleName>,
     /// An element to which this spacing rule applies
     pub(crate) pattern: Pattern,
     /// How much space to add/remove at the start or end of the element.
@@ -79,19 +80,32 @@ impl SpacingDsl {
     ///
     /// This is a low-level method for special cases, common cases are handled
     /// by a more convenient `SpacingRuleBuilder`.
-    pub(crate) fn rule(&mut self, rule: SpacingRule) -> &mut SpacingDsl {
+    pub(crate) fn add_rule(&mut self, rule: SpacingRule) -> &mut SpacingDsl {
         self.rules.push(rule);
         self
     }
-    /// Specify a spacing rule for an element which is a child of `parent`.
-    pub(crate) fn inside(&mut self, parent: impl Into<Pattern>) -> SpacingRuleBuilder {
+    /// Add a new rule with the given `name`.
+    pub(crate) fn rule(&mut self, name: &'static str) -> SpacingRuleBuilder<'_> {
         SpacingRuleBuilder {
             dsl: self,
-            parent: parent.into(),
+            rule_name: Some(name),
+            parent: None,
             child: None,
             between: None,
             loc: None,
         }
+    }
+    /// Specify an anonymous spacing rule for an element which is a child of `parent`.
+    pub(crate) fn inside(&mut self, parent: impl Into<Pattern>) -> SpacingRuleBuilder<'_> {
+        SpacingRuleBuilder {
+            dsl: self,
+            rule_name: None,
+            parent: None,
+            child: None,
+            between: None,
+            loc: None,
+        }
+        .inside(parent)
     }
     pub(crate) fn test(&mut self, before: &'static str, after: &'static str) -> &mut SpacingDsl {
         #[cfg(test)]
@@ -106,13 +120,19 @@ impl SpacingDsl {
 /// A builder to conveniently specify a single rule.
 pub(crate) struct SpacingRuleBuilder<'a> {
     dsl: &'a mut SpacingDsl,
-    parent: Pattern,
+    rule_name: Option<&'static str>,
+    parent: Option<Pattern>,
     child: Option<Pattern>,
     between: Option<(Pattern, Pattern)>,
     loc: Option<SpaceLoc>,
 }
 
 impl<'a> SpacingRuleBuilder<'a> {
+    /// The rule applies to direct children of the `parent` element.
+    pub(crate) fn inside(mut self, parent: impl Into<Pattern>) -> SpacingRuleBuilder<'a> {
+        self.parent = Some(parent.into());
+        self
+    }
     /// The rule applies to both sides of the element `child`.
     pub(crate) fn around(mut self, child: impl Into<Pattern>) -> SpacingRuleBuilder<'a> {
         self.child = Some(child.into());
@@ -172,6 +192,7 @@ impl<'a> SpacingRuleBuilder<'a> {
     }
     fn finish(self, value: SpaceValue) -> &'a mut SpacingDsl {
         assert!(self.between.is_some() ^ self.child.is_some());
+        let parent = self.parent.expect("parent must be set for each rule");
         if let Some((left, right)) = self.between {
             let child = {
                 let left = left.clone();
@@ -181,26 +202,29 @@ impl<'a> SpacingRuleBuilder<'a> {
                 })
             };
             let rule = SpacingRule {
-                pattern: child.with_parent(self.parent.clone()),
+                name: self.rule_name.map(RuleName),
+                pattern: child.with_parent(parent.clone()),
                 space: Space { value, loc: SpaceLoc::After },
             };
-            self.dsl.rule(rule);
+            self.dsl.add_rule(rule);
 
             let child = right
                 & Pattern::from(move |it: &SyntaxElement| {
                     prev_non_whitespace_sibling(it).map(|it| left.matches(&it)) == Some(true)
                 });
             let rule = SpacingRule {
-                pattern: child.with_parent(self.parent),
+                name: self.rule_name.map(RuleName),
+                pattern: child.with_parent(parent),
                 space: Space { value, loc: SpaceLoc::Before },
             };
-            self.dsl.rule(rule);
+            self.dsl.add_rule(rule);
         } else {
             let rule = SpacingRule {
-                pattern: self.child.unwrap().with_parent(self.parent),
+                name: self.rule_name.map(RuleName),
+                pattern: self.child.unwrap().with_parent(parent),
                 space: Space { value, loc: self.loc.unwrap() },
             };
-            self.dsl.rule(rule);
+            self.dsl.add_rule(rule);
         }
         self.dsl
     }

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -219,7 +219,7 @@ pub(crate) enum IndentValue {
 pub(crate) struct RuleName(&'static str);
 
 impl RuleName {
-    fn new(name: &'static str) -> RuleName {
+    pub(crate) fn new(name: &'static str) -> RuleName {
         assert!(name.chars().next().unwrap().is_uppercase(), "rule names should be capitalized");
         assert!(name.chars().last().unwrap() != '.', "rule names should not end in `.`");
         RuleName(name)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8,7 +8,7 @@ mod fixes;
 use rnix::{SmolStr, SyntaxNode, TextRange};
 
 use crate::{
-    dsl::{IndentDsl, SpacingDsl},
+    dsl::{IndentDsl, RuleName, SpacingDsl},
     engine::fmt_model::{BlockPosition, FmtModel, SpaceBlock, SpaceBlockOrToken},
     pattern::PatternSet,
     tree_utils::walk_non_whitespace,
@@ -73,7 +73,7 @@ pub(crate) fn format(
 }
 
 impl FmtDiff {
-    fn replace(&mut self, range: TextRange, text: SmolStr) {
-        self.edits.push((AtomEdit { delete: range, insert: text }, None))
+    fn replace(&mut self, range: TextRange, text: SmolStr, reason: Option<RuleName>) {
+        self.edits.push((AtomEdit { delete: range, insert: text }, reason))
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -74,6 +74,6 @@ pub(crate) fn format(
 
 impl FmtDiff {
     fn replace(&mut self, range: TextRange, text: SmolStr) {
-        self.edits.push(AtomEdit { delete: range, insert: text })
+        self.edits.push((AtomEdit { delete: range, insert: text }, None))
     }
 }

--- a/src/engine/fmt_model.rs
+++ b/src/engine/fmt_model.rs
@@ -145,7 +145,7 @@ impl FmtModel {
                 diff.replace(block.original.text_range(), change.new_text);
             }
         }
-        diff.edits.extend(self.fixes.into_iter());
+        diff.edits.extend(self.fixes.into_iter().map(|edit| (edit, None)));
         diff
     }
 

--- a/src/engine/fmt_model.rs
+++ b/src/engine/fmt_model.rs
@@ -90,19 +90,19 @@ impl SpaceBlock {
         };
         SpaceBlock { original, change: None, semantic_newline }
     }
-    pub(super) fn set_line_break_preserving_existing_newlines(&mut self) {
+    pub(super) fn set_line_break_preserving_existing_newlines(&mut self, rule: Option<RuleName>) {
         if self.has_newline() {
             return;
         }
-        self.set_text("\n");
+        self.set_text("\n", rule);
     }
-    pub(super) fn set_text(&mut self, text: &str) {
+    pub(super) fn set_text(&mut self, text: &str, rule: Option<RuleName>) {
         if self.semantic_newline && !text.contains('\n') {
             return;
         }
         match &self.original {
             OriginalSpace::Some(token) if token.text() == text && self.change.is_none() => return,
-            _ => self.change = Some(SpaceChange { new_text: text.into(), originating_rule: None }),
+            _ => self.change = Some(SpaceChange { new_text: text.into(), originating_rule: rule }),
         }
     }
     pub(super) fn text(&self) -> &str {

--- a/src/engine/fmt_model.rs
+++ b/src/engine/fmt_model.rs
@@ -55,7 +55,7 @@ pub(super) struct SpaceBlock {
 #[derive(Debug)]
 struct SpaceChange {
     new_text: SmolStr,
-    originating_rule: Option<RuleName>,
+    reason: Option<RuleName>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -103,7 +103,7 @@ impl SpaceBlock {
         self.change = match &self.original {
             OriginalSpace::Some(token) if token.text() == text => None,
             OriginalSpace::None { .. } if text.is_empty() => None,
-            _ => Some(SpaceChange { new_text: text.into(), originating_rule: rule }),
+            _ => Some(SpaceChange { new_text: text.into(), reason: rule }),
         }
     }
     pub(super) fn text(&self) -> &str {
@@ -143,7 +143,7 @@ impl FmtModel {
         let mut diff = FmtDiff { original_node: self.original_node.to_owned(), edits: vec![] };
         for block in self.blocks {
             if let Some(change) = block.change {
-                diff.replace(block.original.text_range(), change.new_text, change.originating_rule);
+                diff.replace(block.original.text_range(), change.new_text, change.reason);
             }
         }
         diff.edits.extend(self.fixes.into_iter().map(|edit| (edit, None)));

--- a/src/engine/indentation.rs
+++ b/src/engine/indentation.rs
@@ -6,7 +6,7 @@ use std::{
 use rnix::{SmolStr, SyntaxElement, SyntaxKind::NODE_ROOT, SyntaxNode, TextUnit};
 
 use crate::{
-    dsl::{IndentRule, Modality},
+    dsl::{IndentRule, Modality, RuleName},
     engine::{BlockPosition, FmtModel, SpaceBlock, SpaceBlockOrToken},
     pattern::{Pattern, PatternSet},
 };
@@ -155,14 +155,14 @@ impl IndentRule {
             _ => IndentLevel::default(),
         };
         let block = model.block_for(element, BlockPosition::Before);
-        block.set_indent(anchor_indent.indent());
+        block.set_indent(anchor_indent.indent(), self.name);
     }
 }
 
 impl SpaceBlock {
-    fn set_indent(&mut self, indent: IndentLevel) {
+    fn set_indent(&mut self, indent: IndentLevel, rule: RuleName) {
         let newlines: String = self.text().chars().filter(|&it| it == '\n').collect();
-        self.set_text(&format!("{}{}", newlines, indent));
+        self.set_text(&format!("{}{}", newlines, indent), Some(rule));
     }
 
     fn indent(&self) -> IndentLevel {
@@ -180,7 +180,7 @@ pub(super) fn default_indent(
         _ => IndentLevel::default(),
     };
     let block = model.block_for(element, BlockPosition::Before);
-    block.set_indent(anchor_indent);
+    block.set_indent(anchor_indent, RuleName::new("Preserve indentation"));
 }
 
 /// Computes an anchoring element, together with its indent.

--- a/src/engine/spacing.rs
+++ b/src/engine/spacing.rs
@@ -1,7 +1,7 @@
 use rnix::SyntaxElement;
 
 use crate::{
-    dsl::{SpaceLoc, SpaceValue, SpacingRule},
+    dsl::{RuleName, SpaceLoc, SpaceValue, SpacingRule},
     engine::{BlockPosition, FmtModel, SpaceBlock},
     tree_utils::has_newline,
 };
@@ -13,11 +13,11 @@ impl SpacingRule {
         }
         if self.space.loc.is_before() {
             let block = model.block_for(element, BlockPosition::Before);
-            ensure_space(element, block, self.space.value);
+            ensure_space(element, block, self.space.value, self.name);
         }
         if self.space.loc.is_after() {
             let block = model.block_for(element, BlockPosition::After);
-            ensure_space(element, block, self.space.value);
+            ensure_space(element, block, self.space.value, self.name);
         }
     }
 }
@@ -37,19 +37,24 @@ impl SpaceLoc {
     }
 }
 
-fn ensure_space(element: &SyntaxElement, block: &mut SpaceBlock, value: SpaceValue) {
+fn ensure_space(
+    element: &SyntaxElement,
+    block: &mut SpaceBlock,
+    value: SpaceValue,
+    rule_name: Option<RuleName>,
+) {
     match value {
-        SpaceValue::Single => block.set_text(" ", None),
+        SpaceValue::Single => block.set_text(" ", rule_name),
         SpaceValue::SingleOptionalNewline => {
             if !block.has_newline() {
-                block.set_text(" ", None)
+                block.set_text(" ", rule_name)
             }
         }
-        SpaceValue::Newline => block.set_text("\n", None),
-        SpaceValue::None => block.set_text("", None),
+        SpaceValue::Newline => block.set_text("\n", rule_name),
+        SpaceValue::None => block.set_text("", rule_name),
         SpaceValue::NoneOptionalNewline => {
             if !block.has_newline() {
-                block.set_text("", None)
+                block.set_text("", rule_name)
             }
         }
         SpaceValue::SingleOrNewline => {
@@ -57,7 +62,7 @@ fn ensure_space(element: &SyntaxElement, block: &mut SpaceBlock, value: SpaceVal
             if parent_is_multiline {
                 block.set_line_break_preserving_existing_newlines(None)
             } else {
-                block.set_text(" ", None)
+                block.set_text(" ", rule_name)
             }
         }
         SpaceValue::NoneOrNewline => {
@@ -65,7 +70,7 @@ fn ensure_space(element: &SyntaxElement, block: &mut SpaceBlock, value: SpaceVal
             if parent_is_multiline {
                 block.set_line_break_preserving_existing_newlines(None)
             } else {
-                block.set_text("", None)
+                block.set_text("", rule_name)
             }
         }
     }

--- a/src/engine/spacing.rs
+++ b/src/engine/spacing.rs
@@ -39,33 +39,33 @@ impl SpaceLoc {
 
 fn ensure_space(element: &SyntaxElement, block: &mut SpaceBlock, value: SpaceValue) {
     match value {
-        SpaceValue::Single => block.set_text(" "),
+        SpaceValue::Single => block.set_text(" ", None),
         SpaceValue::SingleOptionalNewline => {
             if !block.has_newline() {
-                block.set_text(" ")
+                block.set_text(" ", None)
             }
         }
-        SpaceValue::Newline => block.set_text("\n"),
-        SpaceValue::None => block.set_text(""),
+        SpaceValue::Newline => block.set_text("\n", None),
+        SpaceValue::None => block.set_text("", None),
         SpaceValue::NoneOptionalNewline => {
             if !block.has_newline() {
-                block.set_text("")
+                block.set_text("", None)
             }
         }
         SpaceValue::SingleOrNewline => {
             let parent_is_multiline = element.parent().map_or(false, |it| has_newline(&it));
             if parent_is_multiline {
-                block.set_line_break_preserving_existing_newlines()
+                block.set_line_break_preserving_existing_newlines(None)
             } else {
-                block.set_text(" ")
+                block.set_text(" ", None)
             }
         }
         SpaceValue::NoneOrNewline => {
             let parent_is_multiline = element.parent().map_or(false, |it| has_newline(&it));
             if parent_is_multiline {
-                block.set_line_break_preserving_existing_newlines()
+                block.set_line_break_preserving_existing_newlines(None)
             } else {
-                block.set_text("")
+                block.set_text("", None)
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ pub struct AtomEdit {
 
 impl FmtDiff {
     /// Get the diff of deletes and inserts
-    pub fn text_diff(&self) -> &[AtomEdit] {
-        &self.edits
+    pub fn text_diff(&self) -> Vec<AtomEdit> {
+        self.edits.to_vec()
     }
 
     /// Whether or not formatting did caused any changes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ mod tests {
         assert_eq!(
             explanation,
             "{
-foo =1;  # [1; 2): Indent attribute set content, [7; 7): unnamed rule
+foo =1;  # [1; 2): Indent attribute set content, [7; 7): Space after =
 }
 "
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ mod pattern;
 
 use std::borrow::Cow;
 
-use rnix::{SmolStr, SyntaxNode, TextRange};
+use rnix::{SmolStr, SyntaxNode, TextRange, TextUnit};
 
-use crate::{dsl::RuleName, tree_utils::walk_tokens};
+use crate::dsl::RuleName;
 
 /// The result of formatting.
 ///
@@ -41,8 +41,7 @@ impl FmtDiff {
     /// Apply the formatting suggestions and return the new string
     pub fn to_string(&self) -> String {
         // TODO: don't copy strings all over the place
-        let old_text =
-            walk_tokens(&self.original_node).map(|it| it.to_string()).collect::<String>();
+        let old_text = self.original_node.to_string();
 
         let mut total_len = old_text.len();
         let mut edits = self.text_diff();
@@ -66,6 +65,38 @@ impl FmtDiff {
         }
         buf.push_str(&old_text[prev..]);
         assert_eq!(buf.len(), total_len);
+        buf
+    }
+
+    pub fn explain(&self) -> String {
+        let mut buf = String::new();
+        let mut line_start: TextUnit = 0.into();
+        for line in self.original_node.to_string().lines() {
+            let line_len = TextUnit::of_str(line) + TextUnit::of_str("\n");
+            let line_range = TextRange::offset_len(line_start, line_len);
+
+            buf.push_str(line);
+            let mut first = true;
+            for (edit, reason) in self.edits.iter() {
+                if line_range.contains(edit.delete.end()) {
+                    if first {
+                        first = false;
+                        buf.push_str("  # ")
+                    } else {
+                        buf.push_str(", ")
+                    }
+                    buf.push_str(&format!("{}: ", edit.delete));
+                    if let Some(reason) = reason {
+                        buf.push_str(&reason.to_string());
+                    } else {
+                        buf.push_str("unnamed rule")
+                    }
+                }
+            }
+            buf.push('\n');
+
+            line_start += line_len;
+        }
         buf
     }
 
@@ -99,6 +130,14 @@ pub fn reformat_string(text: &str) -> String {
     }
 }
 
+pub fn explain(text: &str) -> String {
+    let (text, _line_endings) = convert_to_unix_line_endings(text);
+    let ast = rnix::parse(&*text);
+    let root_node = ast.node();
+    let diff = reformat_node(&root_node);
+    diff.explain()
+}
+
 enum LineEndings {
     Unix,
     Dos,
@@ -128,5 +167,18 @@ mod tests {
     #[test]
     fn converts_tabs_to_spaces() {
         assert_eq!(&reformat_string("{\n\tfoo = 92;\t}\n"), "{\n  foo = 92;\n}\n");
+    }
+
+    #[test]
+    fn explain_smoke_test() {
+        let input = "{\nfoo =1;\n}\n";
+        let explanation = explain(input);
+        assert_eq!(
+            explanation,
+            "{
+foo =1;  # [1; 2): Indent attribute set content, [7; 7): unnamed rule
+}
+"
+        )
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -18,8 +18,11 @@ pub(crate) fn spacing() -> SpacingDsl {
 
     dsl
         .test("{ a=92; }", "{ a = 92; }")
-        .inside(NODE_SET_ENTRY).before(T![=]).single_space()
-        .inside(NODE_SET_ENTRY).after(T![=]).single_space_or_optional_newline()
+        .rule("Space before =")
+            .inside(NODE_SET_ENTRY).before(T![=]).single_space()
+
+        .rule("Space after =")
+            .inside(NODE_SET_ENTRY).after(T![=]).single_space_or_optional_newline()
 
         .test("{ a = 92 ; }", "{ a = 92; }")
         .inside(NODE_SET_ENTRY).before(T![;]).no_space_or_optional_newline()
@@ -105,17 +108,20 @@ pub(crate) fn spacing() -> SpacingDsl {
         //              }: body
         // }
         // ```
-        .rule(dsl::SpacingRule {
+        .add_rule(dsl::SpacingRule {
+            name: None,
             pattern: p(TOKEN_ASSIGN) & p(next_sibling_is_multiline_lambda_pattern),
             space: dsl::Space { loc: dsl::SpaceLoc::After, value: dsl::SpaceValue::Newline }
         })
 
         // special-cased rules for leading and trailing whitespace
-        .rule(dsl::SpacingRule {
+        .add_rule(dsl::SpacingRule {
+            name: None,
             pattern: NODE_ROOT.into(),
             space: dsl::Space { loc: dsl::SpaceLoc::Before, value: dsl::SpaceValue::None }
         })
-        .rule(dsl::SpacingRule {
+        .add_rule(dsl::SpacingRule {
+            name: None,
             pattern: NODE_ROOT.into(),
             space: dsl::Space { loc: dsl::SpaceLoc::After, value: dsl::SpaceValue::Newline }
         })


### PR DESCRIPTION
This implements the basic scaffold for explain mode, which prints original source code with the names of the rules which caused whitespace changes. 

I didn't try to do anything fancy here, just print the changes next to the changed lines. We might investigate https://docs.rs/annotate-snippets/0.6.1/annotate_snippets/ in the future, if we want something nicer.

Note that at the moment only indent ruels are named