### PR TITLE
Fix Nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,7 @@ let
     src = ./.;
   };
 in
-pkgs.naersk.buildPackage src {
+pkgs.naersk.buildPackage {
+  inherit src;
   cratePaths = [ "." ];
 }


### PR DESCRIPTION
My PR https://github.com/nix-community/nixpkgs-fmt/pull/153 just broke the build. I'm really sorry about that. This fixes it.

Context: the nearsk `buildPackage` function now takes arguments differently: https://github.com/nmattia/naersk/commit/4714fb8ac180e72facffa42dd652ed460b07d9aa