### PR TITLE
Fix #161: Align the function apply with the attribute set

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -99,6 +99,7 @@ pub(crate) fn spacing() -> SpacingDsl {
 
         .test("f  x", "f x")
         .inside(NODE_APPLY).between(VALUES, VALUES).single_space_or_optional_newline()
+        .inside(NODE_APPLY).after(NODE_SELECT).when(next_sibling_is_paren).single_space_or_newline()
 
         .test("if  cond  then  tru  else  fls", "if cond then tru else fls")
         .inside(NODE_IF_ELSE).after(T![if]).single_space_or_optional_newline()
@@ -173,6 +174,12 @@ fn next_sibling_has_newline(element: &SyntaxElement) -> bool {
     element
         .next_sibling_or_token()
         .and_then(|e| e.into_token().map(|t| t.text().contains("\n")))
+        .unwrap_or(false)
+}
+
+fn next_sibling_is_paren(element: &SyntaxElement) -> bool {
+    next_non_whitespace_sibling(element)
+        .and_then(|e| e.into_node().map(|t| t.kind() == NODE_PAREN))
         .unwrap_or(false)
 }
 

--- a/test_data/issue-161.bad.nix
+++ b/test_data/issue-161.bad.nix
@@ -1,0 +1,17 @@
+(
+  builtins.foldl' (
+    acc: v: let
+      isOperator = builtins.typeOf v == "list";
+      operator = if isOperator then (builtins.elemAt v 0) else acc.operator;
+    in
+      if isOperator then (acc // { inherit operator; }) else {
+        inherit operator;
+        state = operators."${operator}" acc.state (satisfiesSemver pythonVersion v);
+      }
+  )
+    {
+      operator = ",";
+      state = true;
+    }
+    tokens
+).state;

--- a/test_data/issue-161.bad.nix
+++ b/test_data/issue-161.bad.nix
@@ -14,4 +14,4 @@
       state = true;
     }
     tokens
-).state;
+).state

--- a/test_data/issue-161.good.nix
+++ b/test_data/issue-161.good.nix
@@ -16,4 +16,4 @@
       state = true;
     }
     tokens
-).state;
+).state

--- a/test_data/issue-161.good.nix
+++ b/test_data/issue-161.good.nix
@@ -1,0 +1,19 @@
+(
+  builtins.foldl'
+    (
+      acc: v:
+        let
+          isOperator = builtins.typeOf v == "list";
+          operator = if isOperator then (builtins.elemAt v 0) else acc.operator;
+        in
+          if isOperator then (acc // { inherit operator; }) else {
+            inherit operator;
+            state = operators."${operator}" acc.state (satisfiesSemver pythonVersion v);
+          }
+    )
+    {
+      operator = ",";
+      state = true;
+    }
+    tokens
+).state;


### PR DESCRIPTION
This PR only force linebreak if after the apply function exists parenthesis. The curly bracket will remain inline.