### PR TITLE
Fix #158 spacing and indentation on node if then else

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -49,6 +49,7 @@ pub(crate) fn format(
         // ```
         //
         // we only indent top-level node (lambda), and not it's first child (parameter)
+        // TODO : Remove it when refactoring indentation engine.
         if element.parent().map(|it| it.text_range().start()) == Some(element.text_range().start())
         {
             continue;

--- a/test_data/issue-158.bad.nix
+++ b/test_data/issue-158.bad.nix
@@ -1,0 +1,12 @@
+{
+foo = if bar != null
+then bar
+      else baz;
+bar =
+if bar == null
+then foo
+else baz;
+qux = if bux == null then nux else baz;
+nux = if foo == baz then bar
+else bar;
+}

--- a/test_data/issue-158.good.nix
+++ b/test_data/issue-158.good.nix
@@ -1,0 +1,15 @@
+{
+  foo =
+    if bar != null
+    then bar
+    else baz;
+  bar =
+    if bar == null
+    then foo
+    else baz;
+  qux = if bux == null then nux else baz;
+  nux =
+    if foo == baz
+    then bar
+    else bar;
+}


### PR DESCRIPTION
Note: In addition to #158, node `if .. else` will not be expanded if `if .. else` is after `in` token.