### PR TITLE
Fix #181: remove forcing newline before close parentheses

### DIFF
--- a/test_data/issue-181.bad.nix
+++ b/test_data/issue-181.bad.nix
@@ -1,0 +1,6 @@
+{ python3 }:
+python3.pkgs.buildPythonApplication {
+ propagatedBuildInputs = (with python3.pkgs; [
+ pkg1
+]);
+}

--- a/test_data/issue-181.good.nix
+++ b/test_data/issue-181.good.nix
@@ -1,0 +1,6 @@
+{ python3 }:
+python3.pkgs.buildPythonApplication {
+  propagatedBuildInputs = (with python3.pkgs; [
+    pkg1
+  ]);
+}


### PR DESCRIPTION
This PR try to make parentheses more relax on forcing newline before close parentheses.