### PR TITLE
Minor fix: forcing newline in close parentheses to match node let beh…

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -12,7 +12,8 @@ use crate::{
     tree_utils::{
         get_parent, has_newline, next_non_whitespace_parent, next_non_whitespace_sibling,
         next_token_sibling, not_on_top_level, on_top_level, prev_non_whitespace_parent,
-        prev_non_whitespace_sibling, prev_sibling, prev_token_sibling, walk_tokens,
+        prev_non_whitespace_sibling, prev_sibling, prev_token_sibling, walk_non_whitespace,
+        walk_tokens,
     },
 };
 
@@ -65,11 +66,14 @@ pub(crate) fn spacing() -> SpacingDsl {
         .inside(NODE_PAREN).before(T!["("]).when(paren_inside_list).when(parent_has_newline).newline()
         .inside(NODE_PAREN).after(T!["("]).no_space_or_optional_newline()
         .inside(NODE_PAREN).after(T!["("]).when(paren_has_token_update).newline()
-        .inside(NODE_PAREN).before(T![")"]).no_space_or_optional_newline()
+        .inside(NODE_PAREN).after(T!["("]).when(around_paren_has_newline).newline()
+        .inside(NODE_PAREN).after(T!["("]).when(next_is_attrset).no_space()
+        .inside(NODE_PAREN).after(T!["("]).when(next_is_lambda_and_has_let).no_space()
+        .inside(NODE_PAREN).before(T![")"]).no_space()
         .inside(NODE_PAREN).before(T![")"]).when(paren_inside_list).no_space()
         .inside(NODE_PAREN).before(T![")"]).when(prev_paren_has_update).when(parent_has_newline).newline()
         .inside(NODE_PAREN).before(T![")"]).when(around_paren_has_newline).newline()
-        .inside(NODE_PAREN).before(T![")"]).when(prev_is_attrset).no_space() 
+        .inside(NODE_PAREN).before(T![")"]).when(prev_is_attrset).no_space()
         .inside(NODE_PAREN).before(T![")"]).when(prev_is_let).when(paren_on_top_level).newline()
         .test("{foo = 92;}", "{ foo = 92; }")
         .inside(NODE_ATTR_SET).after(T!["{"]).single_space_or_newline()
@@ -235,6 +239,19 @@ fn prev_is_attrset(element: &SyntaxElement) -> bool {
         .unwrap_or(false)
 }
 
+fn next_is_lambda_and_has_let(element: &SyntaxElement) -> bool {
+    let is_lambda = next_non_whitespace_sibling(element)
+        .and_then(|e| e.into_node().map(|n| n.kind() == NODE_LAMBDA))
+        .unwrap_or(false);
+
+    let token_let = element
+        .parent()
+        .map(|n| walk_non_whitespace(&n).any(|it| it.kind() == NODE_LET_IN))
+        .unwrap_or(false);
+
+    token_let & is_lambda
+}
+
 fn prev_is_let(element: &SyntaxElement) -> bool {
     prev_non_whitespace_sibling(element)
         .and_then(|e| e.into_node().map(|n| n.kind() == NODE_LET_IN))
@@ -253,14 +270,25 @@ fn paren_on_top_level(element: &SyntaxElement) -> bool {
     }
 }
 
+fn after_token_has_newline(element: &SyntaxElement) -> bool {
+    next_token_sibling(element).map(|e| e.text().contains("\n")).unwrap_or(false)
+}
+
+fn before_token_has_newline(element: &SyntaxElement) -> bool {
+    prev_token_sibling(element).map(|e| e.text().contains("\n")).unwrap_or(false)
+}
+
 fn around_paren_has_newline(element: &SyntaxElement) -> bool {
-    fn after_open_paren_is_newline(element: &SyntaxElement) -> Option<bool> {
-        let get_open_paren = get_parent(element)?.first_child_or_token()?;
-        next_token_sibling(&get_open_paren).map(|e| e.text().contains("\n"))
+    fn around_paren_is_newline(element: &SyntaxElement) -> Option<bool> {
+        if element.as_token()?.kind() == TOKEN_PAREN_CLOSE {
+            let open_paren = get_parent(element)?.first_child_or_token()?;
+            Some(after_token_has_newline(&open_paren) | before_token_has_newline(element))
+        } else {
+            let close_paren = get_parent(element)?.last_child_or_token()?;
+            Some(after_token_has_newline(element) | before_token_has_newline(&close_paren))
+        }
     }
-    let prev_close_paren_is_newline =
-        prev_token_sibling(element).map(|e| e.text().contains("\n")).unwrap_or(false);
-    (prev_close_paren_is_newline & after_open_paren_is_newline(element).unwrap_or(false)) == true
+    around_paren_is_newline(element) == Some(true)
 }
 
 fn prev_paren_has_update(element: &SyntaxElement) -> bool {

--- a/src/tree_utils.rs
+++ b/src/tree_utils.rs
@@ -64,21 +64,17 @@ pub(crate) fn on_top_level(element: &SyntaxElement) -> bool {
 }
 
 pub(crate) fn next_token_sibling(element: &SyntaxElement) -> Option<SyntaxToken> {
-    successors(element.next_sibling_or_token(), |it| it.next_sibling_or_token()).find_map(
-        |element| match element {
-            NodeOrToken::Node(_) => None,
-            NodeOrToken::Token(it) => Some(it),
-        },
-    )
+    match element.next_sibling_or_token()? {
+        NodeOrToken::Node(_) => None,
+        NodeOrToken::Token(it) => Some(it),
+    }
 }
 
 pub(crate) fn prev_token_sibling(element: &SyntaxElement) -> Option<SyntaxToken> {
-    successors(element.prev_sibling_or_token(), |it| it.prev_sibling_or_token()).find_map(
-        |element| match element {
-            NodeOrToken::Node(_) => None,
-            NodeOrToken::Token(it) => Some(it),
-        },
-    )
+    match element.prev_sibling_or_token()? {
+        NodeOrToken::Node(_) => None,
+        NodeOrToken::Token(it) => Some(it),
+    }
 }
 
 pub(crate) fn prev_non_whitespace_token_sibling(element: &SyntaxElement) -> Option<SyntaxToken> {

--- a/test_data/issue-161.good.nix
+++ b/test_data/issue-161.good.nix
@@ -1,15 +1,14 @@
 (
   builtins.foldl'
-    (
-      acc: v:
-        let
-          isOperator = builtins.typeOf v == "list";
-          operator = if isOperator then (builtins.elemAt v 0) else acc.operator;
-        in
-          if isOperator then (acc // { inherit operator; }) else {
-            inherit operator;
-            state = operators."${operator}" acc.state (satisfiesSemver pythonVersion v);
-          }
+    (acc: v:
+      let
+        isOperator = builtins.typeOf v == "list";
+        operator = if isOperator then (builtins.elemAt v 0) else acc.operator;
+      in
+        if isOperator then (acc // { inherit operator; }) else {
+          inherit operator;
+          state = operators."${operator}" acc.state (satisfiesSemver pythonVersion v);
+        }
     )
     {
       operator = ",";

--- a/test_data/issue-181.bad.nix
+++ b/test_data/issue-181.bad.nix
@@ -1,6 +1,10 @@
 { python3 }:
 python3.pkgs.buildPythonApplication {
- propagatedBuildInputs = (with python3.pkgs; [
- pkg1
-]);
+   propagatedBuildInputs = (with python3.pkgs; [
+pkg1
+   ]
+   );
+testB = forAllSystems (
+    system:
+    self.apps.${system}.nixpkgs-fmt);
 }

--- a/test_data/issue-181.good.nix
+++ b/test_data/issue-181.good.nix
@@ -1,6 +1,12 @@
 { python3 }:
 python3.pkgs.buildPythonApplication {
-  propagatedBuildInputs = (with python3.pkgs; [
-    pkg1
-  ]);
+  propagatedBuildInputs = (
+    with python3.pkgs; [
+      pkg1
+    ]
+  );
+  testB = forAllSystems (
+    system:
+    self.apps.${system}.nixpkgs-fmt
+  );
 }

--- a/test_data/issue-83-2.bad.nix
+++ b/test_data/issue-83-2.bad.nix
@@ -2,4 +2,4 @@
   a = ''
     foo
   '';
- in a)
+in a)

--- a/test_data/issue-83-3.bad.nix
+++ b/test_data/issue-83-3.bad.nix
@@ -1,0 +1,3 @@
+(foo {
+  inherit bar;
+})

--- a/test_data/issue-83-3.good.nix
+++ b/test_data/issue-83-3.good.nix
@@ -1,0 +1,3 @@
+(foo {
+  inherit bar;
+})


### PR DESCRIPTION
According to https://github.com/nix-community/nixpkgs-fmt/issues/178#issuecomment-590905404, odd parentheses behavior still exist after #182.

This PR try to fix both odd behavior placed in `test_data/issue-83-3.bad.nix` and when there is `NODE LET` inside the parentheses so that `test_data/issue-83.2.bad.nix` can pass. 

I still leave the function to detect when parentheses is on top level to make sure all the test case in the future regarding top level parentheses is addressed.