### PR TITLE
Fix: #166 and #175 - antiquotation in multiline string

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,7 +5,7 @@ mod indentation;
 mod spacing;
 mod fixes;
 
-use rnix::{SmolStr, SyntaxNode, TextRange};
+use rnix::{SmolStr, SyntaxKind::NODE_STRING_INTERPOL, SyntaxNode, TextRange};
 
 use crate::{
     dsl::{IndentDsl, RuleName, SpacingDsl},
@@ -52,6 +52,10 @@ pub(crate) fn format(
         // TODO: Remove it when refactoring indentation engine.
         if element.parent().map(|it| it.text_range().start()) == Some(element.text_range().start())
         {
+            continue;
+        }
+
+        if element.ancestors().any(|e| e.kind() == NODE_STRING_INTERPOL) {
             continue;
         }
 

--- a/test_data/indent_string_literal_interpolation.bad.nix
+++ b/test_data/indent_string_literal_interpolation.bad.nix
@@ -7,4 +7,53 @@ postFixup =  ''
         lldbLibPath=$out/clion-${version}/bin/lldb/linux/lib
         interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
       '';
+
+foo = ''
+    bar = ${builtins.concatStringsSep " " [
+1
+2
+3
+]}
+    bla = hoi
+  '';
+
+bar = ''
+foo
+${
+foo
+}
+foo
+  '';
+
+baz =
+    ''
+foo
+${
+foo
+}
+foo
+    '';
+
+qux =
+    ''
+    bar = ${builtins.concatStringsSep " " [
+1
+2
+3
+]}
+    bla = hoi
+    '';
+
+singleAsciiDoc = value: ''
+  ${
+if lib.hasAttr "example" value
+then ''
+Example::
+${
+builtins.toJSON value.example
+}
+''
+else "No Example:: {blank}"
+    }
+  '';
 }

--- a/test_data/indent_string_literal_interpolation.good.nix
+++ b/test_data/indent_string_literal_interpolation.good.nix
@@ -7,4 +7,53 @@
     lldbLibPath=$out/clion-${version}/bin/lldb/linux/lib
     interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
   '';
+
+  foo = ''
+    bar = ${builtins.concatStringsSep " " [
+      1
+      2
+      3
+    ]}
+    bla = hoi
+  '';
+
+  bar = ''
+    foo
+    ${
+      foo
+    }
+    foo
+  '';
+
+  baz =
+    ''
+      foo
+      ${
+        foo
+      }
+      foo
+    '';
+
+  qux =
+    ''
+      bar = ${builtins.concatStringsSep " " [
+        1
+        2
+        3
+      ]}
+      bla = hoi
+    '';
+
+  singleAsciiDoc = value: ''
+    ${
+      if lib.hasAttr "example" value
+      then ''
+        Example::
+        ${
+          builtins.toJSON value.example
+        }
+      ''
+      else "No Example:: {blank}"
+    }
+  '';
 }


### PR DESCRIPTION
This PR try to solve antiquotation inside `NODE_STRING`. What I am doing in this PR are:
1. looping inside `NODE_STRING_INTERPOL` and apply `set_indent` based on the element`s `anchor`. This is actually work similar to `apply` function for rules.
2. Due to slightly different approach from the `apply` function, the `string_interpol_indent` function has to make additional case for `TOKEN_THEN` and `TOKEN_THEN`. I am not sure if there is any other case that has to be addressed like in `NODE_IF_ELSE`. If too many node/token that should be address in `string_interpol_indent` function, then I have to make it separate function.