### PR TITLE
Alternative interpolation indentation strategy

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -11,7 +11,7 @@ use crate::{
     dsl::{IndentDsl, RuleName, SpacingDsl},
     engine::fmt_model::{BlockPosition, FmtModel, SpaceBlock, SpaceBlockOrToken},
     pattern::PatternSet,
-    tree_utils::walk_non_whitespace,
+    tree_utils::{walk_non_whitespace, walk_non_whitespace_non_interpol},
     AtomEdit, FmtDiff,
 };
 
@@ -49,7 +49,7 @@ pub(crate) fn reformat(
     let mut model = FmtModel::new(node.clone());
 
     let anchor_set = PatternSet::new(indent_dsl.anchors.iter());
-    for element in walk_non_whitespace(&node) {
+    for element in walk_non_whitespace_non_interpol(&node) {
         let block = model.block_for(&element, BlockPosition::Before);
         if !block.has_newline() {
             // No need to indent an element if it doesn't start a line
@@ -81,7 +81,7 @@ pub(crate) fn reformat(
 
     // Finally, do custom touch-ups like re-indenting of string literals and
     // replacing URLs with string literals.
-    for element in walk_non_whitespace(&node) {
+    for element in walk_non_whitespace_non_interpol(&node) {
         fixes::fix(element, &mut model, &anchor_set)
     }
 

--- a/test_data/indent_string_literal_interpolation.bad.nix
+++ b/test_data/indent_string_literal_interpolation.bad.nix
@@ -9,68 +9,55 @@ postFixup =  ''
       '';
 
 foo = ''
-    bar = ${builtins.concatStringsSep " " [
-1
-2
-3
-]}
-    bla = hoi
-  '';
+  bar = ${builtins.concatStringsSep " " [
+    1
+    2
+    3
+  ]}
+  bla = hoi
+'';
 
 bar = ''
-foo
-${
-foo
-}
-foo
+  foo
+  ${
+    foo
+  }
+  foo
   '';
 
 baz =
     ''
 foo
 ${
-foo
+  foo
 }
 foo
     '';
 
 qux =
-    ''
+  ''
     bar = ${builtins.concatStringsSep " " [
-1
-2
-3
-]}
+      1
+      2
+      3
+    ]}
     bla = hoi
-    '';
-
-singleAsciiDoc = value: ''
-  ${
-if lib.hasAttr "example" value
-then ''
-Example::
-${
-builtins.toJSON value.example
-}
-''
-else "No Example:: {blank}"
-    }
   '';
 
 nested_antiquotation = mkBefore
   ''
-  ${optionalString cfg.earlySetup ''
-  ${optionalString cfg.earlySetup ''
-  setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
-  ''}
-  setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
-  ''}
+    ${optionalString cfg.earlySetup ''
+      ${optionalString cfg.earlySetup ''
+        setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+      ''}
+      setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+    ''}
   '';
 
 singleAsciiDoc = value: ''
 Example::
 ${
-builtins.toJSON value.example
+  builtins.toJSON value.example
 }
 '';
 }

--- a/test_data/indent_string_literal_interpolation.good.nix
+++ b/test_data/indent_string_literal_interpolation.good.nix
@@ -9,18 +9,18 @@
   '';
 
   foo = ''
-    bar = ${builtins.concatStringsSep " " [
-      1
-      2
-      3
+        bar = ${builtins.concatStringsSep " " [
+    1
+    2
+    3
     ]}
-    bla = hoi
+        bla = hoi
   '';
 
   bar = ''
     foo
     ${
-      foo
+    foo
     }
     foo
   '';
@@ -29,49 +29,49 @@
     ''
       foo
       ${
-        foo
+      foo
       }
       foo
     '';
 
   qux =
     ''
-      bar = ${builtins.concatStringsSep " " [
-        1
-        2
-        3
+          bar = ${builtins.concatStringsSep " " [
+      1
+      2
+      3
       ]}
-      bla = hoi
+          bla = hoi
     '';
 
   singleAsciiDoc = value: ''
+      ${
+    if lib.hasAttr "example" value
+    then ''
+    Example::
     ${
-      if lib.hasAttr "example" value
-      then ''
-        Example::
-        ${
-          builtins.toJSON value.example
-        }
-      ''
-      else "No Example:: {blank}"
+    builtins.toJSON value.example
     }
+    ''
+    else "No Example:: {blank}"
+        }
   '';
 
   nested_antiquotation =
     mkBefore
       ''
         ${optionalString cfg.earlySetup ''
-          ${optionalString cfg.earlySetup ''
-            setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
-          ''}
-          setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+        ${optionalString cfg.earlySetup ''
+        setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+        ''}
+        setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
         ''}
       '';
 
   singleAsciiDoc = value: ''
     Example::
     ${
-      builtins.toJSON value.example
+    builtins.toJSON value.example
     }
   '';
 }

--- a/test_data/indent_string_literal_interpolation.good.nix
+++ b/test_data/indent_string_literal_interpolation.good.nix
@@ -9,18 +9,18 @@
   '';
 
   foo = ''
-        bar = ${builtins.concatStringsSep " " [
-    1
-    2
-    3
+    bar = ${builtins.concatStringsSep " " [
+      1
+      2
+      3
     ]}
-        bla = hoi
+    bla = hoi
   '';
 
   bar = ''
     foo
     ${
-    foo
+      foo
     }
     foo
   '';
@@ -29,49 +29,36 @@
     ''
       foo
       ${
-      foo
+        foo
       }
       foo
     '';
 
   qux =
     ''
-          bar = ${builtins.concatStringsSep " " [
-      1
-      2
-      3
+      bar = ${builtins.concatStringsSep " " [
+        1
+        2
+        3
       ]}
-          bla = hoi
+      bla = hoi
     '';
-
-  singleAsciiDoc = value: ''
-      ${
-    if lib.hasAttr "example" value
-    then ''
-    Example::
-    ${
-    builtins.toJSON value.example
-    }
-    ''
-    else "No Example:: {blank}"
-        }
-  '';
 
   nested_antiquotation =
     mkBefore
       ''
         ${optionalString cfg.earlySetup ''
-        ${optionalString cfg.earlySetup ''
-        setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
-        ''}
-        setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+          ${optionalString cfg.earlySetup ''
+            setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+          ''}
+          setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
         ''}
       '';
 
   singleAsciiDoc = value: ''
     Example::
     ${
-    builtins.toJSON value.example
+      builtins.toJSON value.example
     }
   '';
 }

--- a/test_data/issue-199.bad.nix
+++ b/test_data/issue-199.bad.nix
@@ -1,7 +1,7 @@
 let
 # comment
 
- 
+
 a = (if true then 1 else 2);
 b = "${if true then "1" else "2"}";
 
@@ -10,18 +10,18 @@ b = "${if true then "1" else "2"}";
 
 
 c = ''
- ${foo (if true then ''
-   bla
- '' else ''
-   blub
+  ${foo (if true then ''
+    bla
+  '' else ''
+    blub
   '')}
 '';
 
 d = ''
- ${if true then ''
-   bla
- '' else ''
-   blub
+  ${if true then ''
+    bla
+  '' else ''
+    blub
   ''}
 '';
 

--- a/test_data/issue-199.good.nix
+++ b/test_data/issue-199.good.nix
@@ -14,7 +14,7 @@ let
       bla
     '' else ''
       blub
-     '')}
+    '')}
   '';
 
   d = ''
@@ -22,7 +22,7 @@ let
       bla
     '' else ''
       blub
-     ''}
+    ''}
   '';
 
 

--- a/test_data/issue-199.good.nix
+++ b/test_data/issue-199.good.nix
@@ -14,7 +14,7 @@ let
       bla
     '' else ''
       blub
-    '')}
+     '')}
   '';
 
   d = ''
@@ -22,7 +22,7 @@ let
       bla
     '' else ''
       blub
-    ''}
+     ''}
   '';
 
 

--- a/test_data/nixpkgs_repository/lib_strings.good.nix
+++ b/test_data/nixpkgs_repository/lib_strings.good.nix
@@ -7,7 +7,7 @@
     assert lib.assertMsg
       (strw <= width)
       "fixedWidthString: requested string length (${
-        toString width}) must not be shorter than actual length (${
-        toString strw})";
+          toString width}) must not be shorter than actual length (${
+          toString strw})";
     if strw == width then str else filler + fixedWidthString reqWidth filler str;
 }

--- a/test_data/nixpkgs_repository/nixos_lib_testing_python.good.nix
+++ b/test_data/nixpkgs_repository/nixos_lib_testing_python.good.nix
@@ -13,7 +13,7 @@
           mkdir -p $out/bin
           echo -n "$testScript" > $out/test-script
           ${lib.optionalString (!skipLint) ''
-            ${python3Packages.black}/bin/black --check --diff $out/test-script
+          ${python3Packages.black}/bin/black --check --diff $out/test-script
           ''}
           ln -s ${testDriver}/bin/nixos-test-driver $out/bin/
           vms=($(for i in ${toString vms}; do echo $i/bin/run-*-vm; done))

--- a/test_data/nixpkgs_repository/nixos_modules_config_console.good.nix
+++ b/test_data/nixpkgs_repository/nixos_modules_config_console.good.nix
@@ -1,10 +1,10 @@
 {
   boot.initrd.preLVMCommands = mkBefore ''
-    kbd_mode ${if isUnicode then "-u" else "-a"} -C /dev/console
-    printf "\033%%${if isUnicode then "G" else "@"}" >> /dev/console
-    loadkmap < ${optimizedKeymap}
-    ${optionalString cfg.earlySetup ''
-      setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+      kbd_mode ${if isUnicode then "-u" else "-a"} -C /dev/console
+      printf "\033%%${if isUnicode then "G" else "@"}" >> /dev/console
+      loadkmap < ${optimizedKeymap}
+      ${optionalString cfg.earlySetup ''
+    setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
     ''}
   '';
 }


### PR DESCRIPTION
This is an approach alternative to #213.

Here, the idea is that we indent string block as a whole, without
looking into it contents at all. To that end we:

* introduce `walk_non_whitespace_non_interpol` funciton, which walks
the tree skipping interpolated nodes
* tweak `node_indent_ranges` to also just shift stuff inside
  intepolated fragments
* remove existing depth-based interpolation strategy