### PR TITLE
flake: use `lib` instead of `stdenv.lib`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
 
       shell = { pkgs }:
         let
-          inherit (pkgs) stdenv darwin;
+          inherit (pkgs) lib stdenv darwin;
 
           rustChan = pkgs.rustChannelOf {
             date = "2020-12-29";
@@ -63,7 +63,7 @@
             pkgs.wasm-pack
             rust
           ]
-          ++ stdenv.lib.optionals stdenv.isDarwin [
+          ++ lib.optionals stdenv.isDarwin [
             darwin.apple_sdk.frameworks.Security
           ]
           ;


### PR DESCRIPTION
This is deprecated per https://github.com/NixOS/nixpkgs/issues/108938.