### PR TITLE
Remove formatting twice on nixpkgs repository

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -12,7 +12,7 @@ use crate::{
     dsl::{IndentDsl, RuleName, SpacingDsl},
     engine::fmt_model::{BlockPosition, FmtModel, SpaceBlock, SpaceBlockOrToken},
     pattern::PatternSet,
-    tree_utils::{walk_non_whitespace, walk_non_whitespace_non_interpol},
+    tree_utils::walk_non_whitespace_non_interpol,
     AtomEdit, FmtDiff,
 };
 
@@ -32,7 +32,7 @@ pub(crate) fn reformat(
     // First, adjust spacing rules between the nodes.
     // This can force some newlines.
     let spacing_rule_set = PatternSet::new(spacing_dsl.rules.iter());
-    for element in walk_non_whitespace(node) {
+    for element in walk_non_whitespace_non_interpol(node) {
         for rule in spacing_rule_set.matching(element.clone()) {
             rule.apply(&element, &mut model)
         }
@@ -56,7 +56,6 @@ pub(crate) fn reformat(
             // No need to indent an element if it doesn't start a line
             continue;
         }
-
         // In cases like
         //
         // ```nix

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -50,7 +50,7 @@ pub(crate) fn spacing() -> SpacingDsl {
         .inside(NODE_LAMBDA).before(T![:]).no_space()
         .inside(NODE_LAMBDA).after(T![:]).single_space_or_optional_newline()
         .inside(NODE_LAMBDA).before(NODE_IF_ELSE).when(not_inline_if).single_space_or_newline()
-        .inside(NODE_LAMBDA).before(NODE_LET_IN).newline()
+        .inside(NODE_LAMBDA).before(NODE_LET_IN).single_space_or_newline()
 
         .test("[1 2 3]", "[ 1 2 3 ]")
         .inside(NODE_LIST).after(T!["["]).single_space_or_newline()
@@ -95,6 +95,7 @@ pub(crate) fn spacing() -> SpacingDsl {
         .inside(NODE_INHERIT).around(NODE_INHERIT_FROM).single_space_or_optional_newline()
         .inside(NODE_INHERIT).around(T![;]).no_space_or_optional_newline()
         .inside(NODE_INHERIT).before(NODE_IDENT).single_space_or_optional_newline()
+        .inside(NODE_INHERIT).before(NODE_OR_DEFAULT).single_space_or_optional_newline()
         .inside(NODE_INHERIT).after(NODE_IDENT).no_space_or_optional_newline()
         .inside(NODE_INHERIT_FROM).after(T!["("]).no_space()
         .inside(NODE_INHERIT_FROM).before(T![")"]).no_space()

--- a/src/tree_utils.rs
+++ b/src/tree_utils.rs
@@ -15,12 +15,6 @@ pub(crate) fn walk(node: &SyntaxNode) -> impl Iterator<Item = SyntaxElement> {
         WalkEvent::Leave(_) => None,
     })
 }
-pub(crate) fn walk_non_whitespace(node: &SyntaxNode) -> impl Iterator<Item = SyntaxElement> {
-    node.preorder_with_tokens().filter_map(|event| match event {
-        WalkEvent::Enter(element) => Some(element).filter(|it| it.kind() != TOKEN_WHITESPACE),
-        WalkEvent::Leave(_) => None,
-    })
-}
 
 pub(crate) fn walk_non_whitespace_non_interpol(
     node: &SyntaxNode,

--- a/test_data/indent_string_literal_interpolation.bad.nix
+++ b/test_data/indent_string_literal_interpolation.bad.nix
@@ -72,4 +72,13 @@ ${
   builtins.toJSON value.example
 }
 '';
+
+script = writeText "build-maven-repository.sh" ''
+  ${lib.concatStrings (map (dep: let
+    fetch = if (url != "") then ((if authenticated then requireFile else fetchurl) {
+      inherit url sha1;
+    }) else "";
+  in ''
+  '') info.dependencies)}
+'';
 }

--- a/test_data/indent_string_literal_interpolation.good.nix
+++ b/test_data/indent_string_literal_interpolation.good.nix
@@ -72,4 +72,13 @@
       builtins.toJSON value.example
     }
   '';
+
+  script = writeText "build-maven-repository.sh" ''
+    ${lib.concatStrings (map (dep: let
+      fetch = if (url != "") then ((if authenticated then requireFile else fetchurl) {
+        inherit url sha1;
+      }) else "";
+    in ''
+    '') info.dependencies)}
+  '';
 }

--- a/test_data/issue-125.good.nix
+++ b/test_data/issue-125.good.nix
@@ -22,8 +22,7 @@ let
   paz = v:
     let x = 3; in
     x;
-  qux = v:
-    let y = 3; in y;
+  qux = v: let y = 3; in y;
   nux = v:
     let
       x = 3;

--- a/test_data/nixpkgs_repository/nixpkgs_idempotent.bad.nix
+++ b/test_data/nixpkgs_repository/nixpkgs_idempotent.bad.nix
@@ -1,0 +1,8 @@
+{ lib }:
+# Operations on attribute sets.
+rec {
+  filterAttrs = pred: set:
+    listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
+
+  inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor;
+}

--- a/test_data/nixpkgs_repository/nixpkgs_idempotent.good.nix
+++ b/test_data/nixpkgs_repository/nixpkgs_idempotent.good.nix
@@ -1,0 +1,8 @@
+{ lib }:
+# Operations on attribute sets.
+rec {
+  filterAttrs = pred: set:
+    listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [ (nameValuePair name v) ] else [ ]) (attrNames set));
+
+  inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor;
+}


### PR DESCRIPTION
This PR does fix reformatting issue with nixpkgs repository by fixing the following:
1.  add format rule for `NODE_OR_DEFAULT`
2. add adding nixpkgs repository test called `nixpks_idempotent.<bad/good>.nix` 
3. remove function `walk_non_whitespace` when apply the spacing rules and use `walk_non_whitespace_non_interpol` instead.