### PR TITLE
fix CLI option output-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,25 +76,26 @@ exists and what role it can play.
 
 ## Usage
 
-`$ nixpkgs-fmt --help 2>&1 || true`
+`$ nixpkgs-fmt --help`
 ```
-nixpkgs-fmt 0.9.0
+nixpkgs-fmt 1.2.0
 Format Nix code
 
 USAGE:
-    nixpkgs-fmt [FLAGS] [FILE]...
+    nixpkgs-fmt [FLAGS] [OPTIONS] [FILE]...
 
 FLAGS:
-        --check            Only test if the formatter would produce differences
-        --explain          Show which rules are violated
-    -h, --help             Prints help information
-        --output-format    Output syntax tree in JSON format
-        --parse            Show syntax tree instead of reformatting
-    -V, --version          Prints version information
+        --check      Only test if the formatter would produce differences
+        --explain    Show which rules are violated
+    -h, --help       Prints help information
+        --parse      Show syntax tree instead of reformatting
+    -V, --version    Prints version information
+
+OPTIONS:
+        --output-format <FORMAT>    Set output format of --parse [default: rnix]  [possible values: rnix, json]
 
 ARGS:
     <FILE>...    File to reformat in place. If no file is passed, read from stdin.
-
 ```
 ### Tree traversal
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ exists and what role it can play.
 
 ## Usage
 
-`$ nixpkgs-fmt --help`
+<!-- `$ nixpkgs-fmt --help 2>&1 || true` -->
 ```
 nixpkgs-fmt 1.2.0
 Format Nix code

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ fn parse_args() -> Result<Args> {
                 .takes_value(true)
                 .requires("parse")
                 .possible_values(&["rnix", "json"])
+                .default_value("rnix")
                 .help("Set output format of --parse"),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,10 @@ fn parse_args() -> Result<Args> {
             Arg::with_name("output-format")
                 .long("output-format")
                 .requires("parse")
+                .value_name("FORMAT")
+                .takes_value(true)
                 .possible_values(&["json"])
-                .help("Output syntax tree in JSON format"),
+                .help("Set output format of --parse. Values: default, json"),
         )
         .arg(
             Arg::with_name("explain")

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn parse_args() -> Result<Args> {
                 .takes_value(true)
                 .requires("parse")
                 .possible_values(&["rnix", "json"])
-                .help("Set output format of --parse. Values: rnix, json"),
+                .help("Set output format of --parse"),
         )
         .arg(
             Arg::with_name("explain")

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ enum Src {
 
 #[derive(Debug)]
 enum OutputFormat {
-    Default,
+    Rnix, // rnix library: ast.root().dump()
     Json,
 }
 
@@ -71,11 +71,11 @@ fn parse_args() -> Result<Args> {
         .arg(
             Arg::with_name("output-format")
                 .long("output-format")
-                .requires("parse")
                 .value_name("FORMAT")
                 .takes_value(true)
-                .possible_values(&["json"])
-                .help("Set output format of --parse. Values: default, json"),
+                .requires("parse")
+                .possible_values(&["rnix", "json"])
+                .help("Set output format of --parse. Values: rnix, json"),
         )
         .arg(
             Arg::with_name("explain")
@@ -100,7 +100,7 @@ fn parse_args() -> Result<Args> {
     let operation = if matches.is_present("parse") {
         let output_format = match matches.value_of("output-format") {
             Some("json") => OutputFormat::Json,
-            _ => OutputFormat::Default,
+            _ => OutputFormat::Rnix,
         };
         Operation::Parse { output_format }
     } else if matches.is_present("explain") {
@@ -178,7 +178,7 @@ fn try_main(args: Args) -> Result<()> {
             let input = read_single_source(&args.src)?;
             let ast = rnix::parse(&input);
             let res = match output_format {
-                OutputFormat::Default => {
+                OutputFormat::Rnix => {
                     let mut buf = String::new();
                     for error in ast.errors() {
                         writeln!(buf, "error: {}", error).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,6 @@ fn parse_args() -> Result<Args> {
                 .long("output-format")
                 .value_name("FORMAT")
                 .takes_value(true)
-                .requires("parse")
                 .possible_values(&["rnix", "json"])
                 .default_value("rnix")
                 .help("Set output format of --parse"),


### PR DESCRIPTION
part of issue https://github.com/nix-community/nixpkgs-fmt/pull/101#issuecomment-824185560

<details>
<summary>test</summary>

```
./target/debug/nixpkgs-fmt --parse --output-format json <( echo null ) | head -n6
{
  "kind": "NODE_ROOT",
  "text_range": [
    0,
    5
  ],

./target/debug/nixpkgs-fmt --parse --output-format rnix <( echo null ) | head -n1
NODE_ROOT 0..5 {

./target/debug/nixpkgs-fmt --help 2>&1 | grep output-format
        --output-format <FORMAT>    Set output format of --parse [default: rnix]  [possible values: rnix, json]

./target/debug/nixpkgs-fmt --parse --output-format invalid-format <( echo null )
error: 'invalid-format' isn't a valid value for '--output-format <FORMAT>'
        [possible values: json, rnix]
```
</details>

<details>
<summary>javascript snippet</summary>

```js
// javascript: parse nix expression to AST
function parseNix(str) {
  const { spawnSync } = require('child_process');
  return JSON.parse(spawnSync(
    'nixpkgs-fmt',
    ['--parse', '--output-format', 'json'], {
    input: str,
    encoding: 'utf8', maxBuffer: Infinity, windowsHide: true,
  }).stdout);
}
```
</details>

todo: update version to 1.2.1?




<details>
<summary>todo: fix ci (why does it call <code>nixpkgs-fmt --output-format</code>?)</summary>

https://github.com/nix-community/nixpkgs-fmt/runs/2402789246

```
   Compiling nixpkgs-fmt v1.2.0 (/home/runner/work/nixpkgs-fmt/nixpkgs-fmt)
    Finished dev [unoptimized + debuginfo] target(s) in 28.70s
     Running `target/debug/nixpkgs-fmt default.nix flake.nix shell.nix`
error: The following required arguments were not provided:
    --parse

USAGE:
    nixpkgs-fmt --output-format <FORMAT> --parse

For more information try --help

Error: Process completed with exit code 1.
```
</details>

<details>
<summary>known issue: slow</summary>

output to json is around 3 times slower than output to "rnix" format
also the "rnix" format feels rather slow
the default nix parser [could be faster](https://github.com/NixOS/nix/issues/1102#issuecomment-259659097)

```
f=/nix/store/v0xwj556c69yppjzylz2diqk66vliswb-nixos-20.09.3857.b2a189a8618/nixos/pkgs/top-level/all-packages.nix

time /tmp/nixpkgs-fmt/target/debug/nixpkgs-fmt --parse $f >/dev/null 

real    0m7.111s
user    0m6.363s
sys     0m0.083s

time /tmp/nixpkgs-fmt/target/debug/nixpkgs-fmt --parse --output-format json $f >/dev/null 

real    0m20.632s
user    0m19.985s
sys     0m0.170s

time nix-instantiate --parse $f >/dev/null 

real    0m0.176s
user    0m0.131s
sys     0m0.029s

# custom regex parser
time node parse.js >/dev/null 

real    0m0.133s
user    0m0.089s
sys     0m0.024s
```

```js
// parse.js
const path = "/nix/store/v0xwj556c69yppjzylz2diqk66vliswb-nixos-20.09.3857.b2a189a8618/nixos/pkgs/top-level/all-packages.nix";

const fs = require('fs');
const src = fs.readFileSync(path, 'utf8');

console.log(src.match(/[^ \t]*? = callPackage .*?;/g).join('\n'));
```
</details>
