### PR TITLE
Properly handle SIGPIPE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "log"
@@ -253,6 +253,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "ignore",
+ "libc",
  "rnix",
  "rowan",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ smol_str = "0.1.17"
 crossbeam-channel = "0.3"
 ignore = "0.4.10"
 clap = "2.33.0"
+libc = "0.2.99"
 
 # Enable serialization support for rnix syntax trees.
 serde_json = "1.0"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,59 @@
+use std::fs::File;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+// It's an important Unix convention that text processing tools such as one might
+// use in a pipeline terminate cleanly if stdout is closed prematurely.  If grep
+// didn't do this, there'd be an error message every time somebody piped it into
+// head.  Unix processes even do this by default -- when a process writes to a
+// closed pipe, it's sent a SIGPIPE signal, which by default terminates the
+// process.  But the Rust runtime ignores SIGPIPE, so Rust programs have to go out
+// of their way to restore the default SIGPIPE behaviour (or emulate it by checking
+// for EPIPE every time they write) to be good Unix citizens.
+fn test_stdout_closed(args: &[&str]) {
+    use libc::{waitpid, SIGPIPE, WIFSIGNALED, WTERMSIG};
+    use std::io::copy;
+    use std::thread::spawn;
+
+    // Drop the child's stdout to close it.
+    let (pid, mut stdin) = {
+        let child = Command::new(env!("CARGO_BIN_EXE_nixpkgs-fmt"))
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        (child.id(), child.stdin.unwrap())
+    };
+
+    spawn(move || {
+        let input_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("test_data/binop_wrap_before.bad.nix");
+        let mut input = File::open(input_path).unwrap();
+        copy(&mut input, &mut stdin).unwrap();
+        drop(stdin)
+    });
+
+    // We have to use libc because we don't have a Child struct any more.
+    let mut wstatus = 0;
+    assert_eq!(unsafe { waitpid(pid as i32, &mut wstatus, 0) }, pid as i32);
+
+    assert!(WIFSIGNALED(wstatus));
+    assert_eq!(WTERMSIG(wstatus), SIGPIPE);
+}
+
+#[test]
+fn stdout_closed() {
+    test_stdout_closed(&[]);
+}
+
+#[test]
+fn stdout_closed_parse() {
+    test_stdout_closed(&["--parse"]);
+}
+
+#[test]
+fn stdout_closed_explain() {
+    test_stdout_closed(&["--explain"]);
+}


### PR DESCRIPTION
Commands that print their results to stdout should terminate on `SIGPIPE`, so that they don't produce error messages when piped into programs like `head` or `less` that might exit before the process is finished.  This is the default behaviour on Unix, but the Rust runtime ignores `SIGPIPE` by default.

For nixpkgs-fmt modes where it makes sense, re-enable the Unix default behaviour of terminating on `SIGPIPE`.  Don't do this when formatting files, because only formatting half the files if stdout was closed would be a surprising behaviour.
