### PR TITLE
Add links to VSCode extensions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ It's also possible to install it directly from this repository:
 
 `nix-env -f https://github.com/nix-community/nixpkgs-fmt/archive/master.tar.gz -iA nixpkgs-fmt`
 
+### VSCode extensions
+
+There are a few VSCode extensions that make using `nixpkgs-fmt` convenient. 
+Check out:
+
+- [B4dM4n.nixpkgs-fmt](https://marketplace.visualstudio.com/items?itemName=B4dM4n.nixpkgs-fmt)
+- [jnoortheen.nix-ide](https://marketplace.visualstudio.com/items?itemName=jnoortheen.nix-ide)
+
 ### pre-commit hook
 
 This project can also be installed as a [pre-commit](https://pre-commit.com/)


### PR DESCRIPTION
See also https://github.com/nix-community/nixpkgs-fmt/issues/157. For users like myself, VSCode extensions are the primary way that I interact with a tool like nixpkgs-fmt. I figure we might as well advertise these sister projects to promote the usage of nixpkgs-fmt.