### PR TITLE
Don't replace tabs with spaces in strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,6 @@ pub fn reformat_node(node: &SyntaxNode) -> SyntaxNode {
 pub fn reformat_string(text: &str) -> String {
     let (mut text, line_endings) = convert_to_unix_line_endings(text);
 
-    // Forcibly convert tabs to spaces as a pre-pass
-    if text.contains('\t') {
-        text = Cow::Owned(text.replace('\t', "  "))
-    }
-
     let ast = rnix::parse(&*text);
     let root_node = ast.node();
     let res = reformat_node(&root_node).to_string();


### PR DESCRIPTION
Maybe I didn't check correctly but to me it seems this still does replacement outside of strings through other means.

`git grep -P "\t" | grep ".nix:"` showed 92 remaining tabs in formatted nixpkgs which all look to be in strings. Unformatted where 134 tabs.

It seemed though that this had other formatting side-effects (Probably because tab characters are now counted differently). These definitely need to be investigated before merging.

Fixes https://github.com/nix-community/nixpkgs-fmt/issues/251

Need to add test of the fixed issue if this fix is actually acceptable.