### PR TITLE
Update `rnix` to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rnix"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294becb48f58c496d96c10a12df290266204ca75c9799be4d04222bfaebb6a37"
+checksum = "065c5eac8e8f7e7b0e7227bdc46e2d8dd7d69fff7a9a2734e21f686bbcb9b2c9"
 dependencies = [
  "cbitset",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/nix-community/nixpkgs-fmt"
 members = [ "./wasm" ]
 
 [dependencies]
-rnix = "0.9.0"
+rnix = "0.10.1"
 smol_str = "0.1.17"
 
 # Dependencies that are used in the binary only


### PR DESCRIPTION
Needed to release `rnix-lsp`[1] with a newer `rnix` later on.

Changes: https://github.com/nix-community/rnix-parser/blob/cd7a310f7a7b87d3afe8ed6703d92e6554de67ab/CHANGELOG.md

[1] https://github.com/nix-community/rnix-lsp