### PR TITLE
refactor: avoid non_fmt_panics warning

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -812,7 +812,7 @@ foo = x:
             .into(),
         }
         .run()
-        .map_err(|e| panic!(e))
+        .map_err(|e| panic!("{}", e))
         .unwrap();
     }
 


### PR DESCRIPTION
- Avoid the following warning:

  ```
  warning: panic message is not a string literal
    --> src/rules.rs:815:29
      |
  815 |         .map_err(|e| panic!(e))
      |                             ^
      |
      = note: `#[warn(non_fmt_panics)]` on by default
      = note: this usage of panic!() is deprecated; it will be a hard error in Rust 2021
      = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
  help: add a "{}" format string to Display the message
      |
  815 |         .map_err(|e| panic!("{}", e))
      |                             +++++
  ```