### PR TITLE
[WIP] Fix RTL attacks inside the Nix expressions

### DIFF
--- a/test_data/rtl_attact_comment_closed.bad.nix
+++ b/test_data/rtl_attact_comment_closed.bad.nix
@@ -1,0 +1,8 @@
+{ lib, hello }:
+{
+  hello-insecure = hello.overrideAttrs (oldAttrs: {
+    meta = oldAttrs.meta // {
+      /* Mark as insecure ⁧⁦/*⁩ ⁦insecure = true;⁩ /*⁩ 2000-00-00 */
+    };
+  });
+}

--- a/test_data/rtl_attact_comment_closed_bad.sh
+++ b/test_data/rtl_attact_comment_closed_bad.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Unicode bidi (RTL) control characters
+# See https://www.unicode.org/reports/tr9/tr9-42.html
+UCHAR_LRE="$(printf "\\u202a")" 
+UCHAR_RLE="$(printf "\\u202b")"
+UCHAR_LRO="$(printf "\\u202d")"
+UCHAR_RLO="$(printf "\\u202e")"
+UCHAR_PDF="$(printf "\\u202c")"
+UCHAR_LRI="$(printf "\\u2066")"
+UCHAR_RLI="$(printf "\\u2067")"
+UCHAR_FSI="$(printf "\\u2068")"
+UCHAR_PDI="$(printf "\\u2069")"
+
+# The RTL section between "/* Mark as insecure " and " */" is properly closed,
+# BUT the repeated /* make the intermediate content seem uncommented.
+
+cat << EOF
+{ lib, hello }:
+{
+  hello-insecure = hello.overrideAttrs (oldAttrs: {
+    meta = oldAttrs.meta // {
+      /* Mark as insecure ${UCHAR_RLI}${UCHAR_LRI}/*${UCHAR_PDI} ${UCHAR_LRI}insecure = true;${UCHAR_PDI} /*${UCHAR_PDI} 2000-00-00 */
+    };
+  });
+}
+EOF

--- a/test_data/rtl_attact_comment_unclosed.bad.nix
+++ b/test_data/rtl_attact_comment_unclosed.bad.nix
@@ -1,0 +1,8 @@
+{ lib, hello }:
+{
+  hello-insecure = hello.overrideAttrs (oldAttrs: {
+    meta = oldAttrs.meta // {
+      /* Mark as insecure‮⁦ insecure = true;⁩⁦ */
+    };
+  });
+}

--- a/test_data/rtl_attact_comment_unclosed.good.nix
+++ b/test_data/rtl_attact_comment_unclosed.good.nix
@@ -1,0 +1,8 @@
+{ lib, hello }:
+{
+  hello-insecure = hello.overrideAttrs (oldAttrs: {
+    meta = oldAttrs.meta // {
+      /* Mark as insecure‮⁦ insecure = true;⁩‬ */
+    };
+  });
+}

--- a/test_data/rtl_attact_comment_unclosed_bad.sh
+++ b/test_data/rtl_attact_comment_unclosed_bad.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Unicode bidi (RTL) control characters
+# See https://www.unicode.org/reports/tr9/tr9-42.html
+UCHAR_LRE="$(printf "\\u202a")" 
+UCHAR_RLE="$(printf "\\u202b")"
+UCHAR_LRO="$(printf "\\u202d")"
+UCHAR_RLO="$(printf "\\u202e")"
+UCHAR_PDF="$(printf "\\u202c")"
+UCHAR_LRI="$(printf "\\u2066")"
+UCHAR_RLI="$(printf "\\u2067")"
+UCHAR_FSI="$(printf "\\u2068")"
+UCHAR_PDI="$(printf "\\u2069")"
+
+cat << EOF
+{ lib, hello }:
+{
+  hello-insecure = hello.overrideAttrs (oldAttrs: {
+    meta = oldAttrs.meta // {
+      /* Mark as insecure${UCHAR_RLO}${UCHAR_LRI} insecure = true;${UCHAR_PDI}${UCHAR_LRI} */
+    };
+  });
+}
+EOF

--- a/test_data/rtl_attact_comment_unclosed_good.sh
+++ b/test_data/rtl_attact_comment_unclosed_good.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Unicode bidi (RTL) control characters
+# See https://www.unicode.org/reports/tr9/tr9-42.html
+UCHAR_LRE="$(printf "\\u202a")" 
+UCHAR_RLE="$(printf "\\u202b")"
+UCHAR_LRO="$(printf "\\u202d")"
+UCHAR_RLO="$(printf "\\u202e")"
+UCHAR_PDF="$(printf "\\u202c")"
+UCHAR_LRI="$(printf "\\u2066")"
+UCHAR_RLI="$(printf "\\u2067")"
+UCHAR_FSI="$(printf "\\u2068")"
+UCHAR_PDI="$(printf "\\u2069")"
+
+cat << EOF
+{ lib, hello }:
+{
+  hello-insecure = hello.overrideAttrs (oldAttrs: {
+    meta = oldAttrs.meta // {
+      /* Mark as insecure${UCHAR_RLO}${UCHAR_LRI} insecure = true;${UCHAR_PDI}${UCHAR_PDF} */
+    };
+  });
+}
+EOF

--- a/test_data/rtl_attact_string_unclosed.bad.nix
+++ b/test_data/rtl_attact_string_unclosed.bad.nix
@@ -1,0 +1,7 @@
+{ lib, hello }:
+let
+  hello-hardened = hello.overrideAttrs (oldAttrs: {
+    pname = oldAttrs.pname ++ "-hardened";
+  });
+in
+builtins.trace "Hardened hello‮⁦-harden⁩⁦" hello

--- a/test_data/rtl_attact_string_unclosed.good.nix
+++ b/test_data/rtl_attact_string_unclosed.good.nix
@@ -1,0 +1,7 @@
+{ lib, hello }:
+let
+  hello-hardened = hello.overrideAttrs (oldAttrs: {
+    pname = oldAttrs.pname ++ "-hardened";
+  });
+in
+builtins.trace "Hardened hello‮⁦-harden⁩‬" hello

--- a/test_data/rtl_attact_string_unclosed_bad.sh
+++ b/test_data/rtl_attact_string_unclosed_bad.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Unicode bidi (RTL) control characters
+# See https://www.unicode.org/reports/tr9/tr9-42.html
+UCHAR_LRE="$(printf "\\u202a")" 
+UCHAR_RLE="$(printf "\\u202b")"
+UCHAR_LRO="$(printf "\\u202d")"
+UCHAR_RLO="$(printf "\\u202e")"
+UCHAR_PDF="$(printf "\\u202c")"
+UCHAR_LRI="$(printf "\\u2066")"
+UCHAR_RLI="$(printf "\\u2067")"
+UCHAR_FSI="$(printf "\\u2068")"
+UCHAR_PDI="$(printf "\\u2069")"
+
+cat << EOF
+{ lib, hello }:
+let
+  hello-hardened = hello.overrideAttrs (oldAttrs: {
+    pname = oldAttrs.pname ++ "-hardened";
+  });
+in
+builtins.trace "Hardened hello${UCHAR_RLO}${UCHAR_LRI}-harden${UCHAR_PDI}${UCHAR_LRI}" hello
+EOF

--- a/test_data/rtl_attact_string_unclosed_good.sh
+++ b/test_data/rtl_attact_string_unclosed_good.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Unicode bidi (RTL) control characters
+# See https://www.unicode.org/reports/tr9/tr9-42.html
+UCHAR_LRE="$(printf "\\u202a")" 
+UCHAR_RLE="$(printf "\\u202b")"
+UCHAR_LRO="$(printf "\\u202d")"
+UCHAR_RLO="$(printf "\\u202e")"
+UCHAR_PDF="$(printf "\\u202c")"
+UCHAR_LRI="$(printf "\\u2066")"
+UCHAR_RLI="$(printf "\\u2067")"
+UCHAR_FSI="$(printf "\\u2068")"
+UCHAR_PDI="$(printf "\\u2069")"
+
+cat << EOF
+{ lib, hello }:
+let
+  hello-hardened = hello.overrideAttrs (oldAttrs: {
+    pname = oldAttrs.pname ++ "-hardened";
+  });
+in
+builtins.trace "Hardened hello${UCHAR_RLO}${UCHAR_LRI}-harden${UCHAR_PDI}${UCHAR_PDF}" hello
+EOF


### PR DESCRIPTION
This is currently a draft PR containing the test data and their generation script as a proof-of-concept exploit of CVE-2021-42574 (Trojan Source).

I have little spare time so far. Any suggestions / another PR containing the test data and the solution would be appreciated.

Closes issue #276