### PR TITLE
feat: add `reformat_edits` function

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -22,7 +22,10 @@ pub(crate) enum ExtraInfo<'a> {
     Explanation(&'a mut Vec<(AtomEdit, Option<RuleName>)>),
     /// Edits contains spacing edits to be applied to the document and indent edits to be applied in
     /// a second, separate transaction.
-    Edits { spacing_edits: &'a mut Vec<AtomEdit>, indent_edits: &'a mut Vec<AtomEdit> },
+    Edits {
+        spacing_edits: &'a mut Vec<AtomEdit>,
+        indent_edits: &'a mut Vec<AtomEdit>,
+    },
     None,
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -18,7 +18,7 @@ use crate::{
 
 pub(crate) enum ExtraInfo<'a> {
     Explanation(&'a mut Vec<(AtomEdit, Option<RuleName>)>),
-    Edits(&'a mut Vec<AtomEdit>, &'a mut Vec<AtomEdit>),
+    Edits { spacing_edits: &'a mut Vec<AtomEdit>, indent_edits: &'a mut Vec<AtomEdit> },
     None,
 }
 
@@ -49,7 +49,7 @@ pub(crate) fn reformat(
         if spacing_diff.has_changes() {
             explanation.extend(spacing_diff.edits.clone())
         }
-    } else if let ExtraInfo::Edits(spacing_edits, _) = &mut extra_info {
+    } else if let ExtraInfo::Edits { spacing_edits, .. } = &mut extra_info {
         spacing_edits
             .extend(spacing_diff.edits.iter().map(|(ae, _)| ae.clone()).collect::<Vec<_>>());
     }
@@ -102,7 +102,7 @@ pub(crate) fn reformat(
         if indent_diff.has_changes() && explanation.is_empty() {
             explanation.extend(indent_diff.edits.clone())
         }
-    } else if let ExtraInfo::Edits(_, indent_edits) = extra_info {
+    } else if let ExtraInfo::Edits { indent_edits, .. } = extra_info {
         indent_edits.extend(indent_diff.edits.iter().map(|(ae, _)| ae.clone()).collect::<Vec<_>>());
     }
     indent_diff.to_node()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -18,6 +18,8 @@ use crate::{
 
 pub(crate) enum ExtraInfo<'a> {
     Explanation(&'a mut Vec<(AtomEdit, Option<RuleName>)>),
+    /// Edits contains spacing edits to be applied to the document and indent edits to be applied in
+    /// a second, separate transaction.
     Edits { spacing_edits: &'a mut Vec<AtomEdit>, indent_edits: &'a mut Vec<AtomEdit> },
     None,
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -17,6 +17,8 @@ use crate::{
 };
 
 pub(crate) enum ExtraInfo<'a> {
+    // Explanation contains a vector of edits, each of which is optionally paired with the rule name
+    // that caused the edit.
     Explanation(&'a mut Vec<(AtomEdit, Option<RuleName>)>),
     /// Edits contains spacing edits to be applied to the document and indent edits to be applied in
     /// a second, separate transaction.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub fn reformat_edits(node: &SyntaxNode) -> (Vec<AtomEdit>, Vec<AtomEdit>) {
         &spacing,
         &indentation,
         node,
-        ExtraInfo::Edits(&mut spacing_edits, &mut indent_edits),
+        ExtraInfo::Edits { spacing_edits: &mut spacing_edits, indent_edits: &mut indent_edits },
     );
     spacing_edits.sort_by(|a, b| a.delete.start().cmp(&b.delete.start()));
     indent_edits.sort_by(|a, b| a.delete.start().cmp(&b.delete.start()));


### PR DESCRIPTION
This pull request exposes a function which returns the spacing edits and indentation edits required to reformat the given node. I'd like to do this so that `rnix-lsp` (which uses this crate), can respond to document formatting requests with multiple small edits instead of responding with one huge edit that replaces the entire document.

I am somewhat unsure of what type these edits should be returned as. Please see the description of the related `rnix-lsp` pull request ([rnix-lsp#87](https://github.com/nix-community/rnix-lsp/pull/87)) for a discussion of that.